### PR TITLE
Use the official default compression level (i.e. 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,22 @@ Or install it yourself as:
 
 ## Usage
 
-```
+```ruby
 require 'zstd-ruby'
 ```
 
 ### compression
 
-```
-Zstd.compress(data)
+```ruby
+compressed_data = Zstd.compress(data)
+compressed_data = Zstd.compress(data, complession_level) # default compression_level is 0
 ```
 
 
 ### decompression
 
-```
-Zstd.decompress(compressed_data)
+```ruby
+data = Zstd.decompress(compressed_data)
 ```
 
 ## Development

--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -21,8 +21,7 @@ static VALUE compress(int argc, VALUE *argv, VALUE self)
   if (NIL_P(compression_level_value)) {
     compression_level = 0; // The default. See ZSTD_CLEVEL_DEFAULT in zstd_compress.c
   } else {
-    Check_Type(compression_level_value, RUBY_T_FIXNUM);
-    compression_level = FIX2INT(compression_level_value);
+    compression_level = NUM2INT(compression_level_value);
   }
 
   // do compress

--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -19,7 +19,7 @@ static VALUE compress(int argc, VALUE *argv, VALUE self)
 
   int compression_level;
   if (NIL_P(compression_level_value)) {
-    compression_level = 1;
+    compression_level = 0; // The default. See ZSTD_CLEVEL_DEFAULT in zstd_compress.c
   } else {
     Check_Type(compression_level_value, RUBY_T_FIXNUM);
     compression_level = FIX2INT(compression_level_value);


### PR DESCRIPTION
In compression level, 0 is better than 1 as the default.

As the source shown, compression level == 0 results in [ZSTD_CLEVEL_DEFAULT](https://github.com/facebook/zstd/blob/v1.3.2/lib/compress/zstd_compress.c#L3007). Because ZSTD_CLEVEL_DEFAULT is not public, the only way to use it is to set 0 (or negative value) as the compression level.

BTW zstd v1.3.2 has been released a few days ago: https://github.com/facebook/zstd/releases