### PR TITLE
Support implicit conversion

### DIFF
--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -13,7 +13,7 @@ static VALUE compress(int argc, VALUE *argv, VALUE self)
   VALUE compression_level_value;
   rb_scan_args(argc, argv, "11", &input_value, &compression_level_value);
 
-  Check_Type(input_value, RUBY_T_STRING);
+  StringValue(input_value);
   const char* input_data = RSTRING_PTR(input_value);
   size_t input_size = RSTRING_LEN(input_value);
 
@@ -81,7 +81,7 @@ static VALUE decompress_buffered(const char* input_data, size_t input_size)
 
 static VALUE decompress(VALUE self, VALUE input)
 {
-  Check_Type(input, T_STRING);
+  StringValue(input);
   const char* input_data = RSTRING_PTR(input);
   size_t input_size = RSTRING_LEN(input);
 

--- a/spec/zstd-ruby_spec.rb
+++ b/spec/zstd-ruby_spec.rb
@@ -24,6 +24,23 @@ RSpec.describe Zstd do
       expect(compressed).to be_a(String)
       expect(compressed).to_not eq('abc')
     end
+
+    it 'should raise exception with unsupported object' do
+      expect { Zstd.compress(Object.new) }.to raise_error(TypeError)
+    end
+
+    class DummyForCompress
+      def to_str
+        'abc'
+      end
+    end
+
+    it 'should convert object implicitly' do
+      compressed = Zstd.compress(DummyForCompress.new)
+      expect(compressed).to be_a(String)
+      decompressed = Zstd.decompress(compressed)
+      expect(decompressed).to eq('abc')
+    end
   end
 
   describe 'decompress' do
@@ -38,6 +55,20 @@ RSpec.describe Zstd do
       expect(compressed.bytesize).to eq(9)
       decompressed = Zstd.decompress(compressed)
       expect(decompressed).to eq('')
+    end
+
+    it 'should raise exception with unsupported object' do
+      expect { Zstd.decompress(Object.new) }.to raise_error(TypeError)
+    end
+
+    class DummyForDecompress
+      def to_str
+        Zstd.compress('abc')
+      end
+    end
+
+    it 'should convert object implicitly' do
+      expect(Zstd.decompress(DummyForDecompress.new)).to eq('abc')
     end
   end
 end


### PR DESCRIPTION
This patch will support to convert argument implicitly if the object has #to_str method, like

```ruby
require 'zstd-ruby'

class Foo
  def to_str
    'abc'
  end
end

compressed = Zstd.compress(Foo.new)
p Zstd.decompress(compressed) # => abc
```