### PR TITLE
Fix build with Ruby 3.1 on macOS 12.1

### DIFF
--- a/ext/zstdruby/extconf.rb
+++ b/ext/zstdruby/extconf.rb
@@ -1,6 +1,6 @@
 require "mkmf"
 
-$CFLAGS = '-I. -O3 -std=c99'
+$CFLAGS = '-I. -O3 -std=c99 -fdeclspec'
 
 Dir.chdir File.expand_path('..', __FILE__) do
     $srcs = Dir['**/*.c']


### PR DESCRIPTION
After installing Ruby 3.1 on my Intel x64 mac 12.1, I got the following errors when trying to build zstd:

```
compiling zstdruby.c
In file included from zstdruby.c:1:
In file included from ./zstdruby.h:4:
In file included from /Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby.h:38:
In file included from /Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby/ruby.h:25:
In file included from /Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby/defines.h:73:
In file included from /Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby/backward/2/attributes.h:42:
In file included from /Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby/internal/attr/pure.h:25:
/Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby/assert.h:132:1: error: '__declspec' attributes are not enabled; use '-fdeclspec' or '-fms-extensions' to enable support for __declspec attributes
RBIMPL_ATTR_NORETURN()
^
/Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby/internal/attr/noreturn.h:29:33: note: expanded from macro 'RBIMPL_ATTR_NORETURN'
# define RBIMPL_ATTR_NORETURN() __declspec(noreturn)
                                ^
In file included from zstdruby.c:1:
In file included from ./zstdruby.h:4:
In file included from /Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby.h:38:
In file included from /Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby/ruby.h:26:
In file included from /Users/michaelscrivo/.rbenv/versions/3.1.0/include/ruby-3.1.0/ruby/internal/anyargs.h:77:```

Adding this compiler flag fixes it and still seems to work on lower Ruby verisons as well.