### PR TITLE
Add Ractor support

### DIFF
--- a/ext/zstdruby/main.c
+++ b/ext/zstdruby/main.c
@@ -7,6 +7,10 @@ void zstd_ruby_streaming_decompress_init(void);
 void
 Init_zstdruby(void)
 {
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+  rb_ext_ractor_safe(true);
+#endif
+
   rb_mZstd = rb_define_module("Zstd");
   zstd_ruby_init();
   zstd_ruby_streaming_compress_init();

--- a/spec/zstd-ruby-streaming-compress_spec.rb
+++ b/spec/zstd-ruby-streaming-compress_spec.rb
@@ -52,5 +52,18 @@ RSpec.describe Zstd::StreamingCompress do
       expect(Zstd.decompress(res)).to eq('abcdef')
     end
   end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+    describe 'Ractor' do
+      it 'should be supported' do
+        r = Ractor.new {
+          stream = Zstd::StreamingCompress.new(5)
+          stream << "abc" << "def"
+          res = stream.finish
+        }
+        expect(Zstd.decompress(r.take)).to eq('abcdef')
+      end
+    end
+  end
 end
 

--- a/spec/zstd-ruby-streaming-decompress_spec.rb
+++ b/spec/zstd-ruby-streaming-decompress_spec.rb
@@ -32,5 +32,21 @@ RSpec.describe Zstd::StreamingDecompress do
     end
   end
 
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+    describe 'Ractor' do
+      it 'should be supported' do
+        r = Ractor.new {
+          cstr = Zstd.compress('foo bar buzz')
+          stream = Zstd::StreamingDecompress.new
+          result = ''
+          result << stream.decompress(cstr[0, 5])
+          result << stream.decompress(cstr[5, 5])
+          result << stream.decompress(cstr[10..-1])
+          result
+        }
+        expect(r.take).to eq('foo bar buzz')
+      end
+    end
+  end
 end
 

--- a/spec/zstd-ruby_spec.rb
+++ b/spec/zstd-ruby_spec.rb
@@ -74,5 +74,14 @@ RSpec.describe Zstd do
       expect(Zstd.decompress(DummyForDecompress.new)).to eq('abc')
     end
   end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+    describe 'Ractor' do
+      it 'should be supported' do
+        r = Ractor.new { Zstd.compress('abc') }
+        expect(Zstd.decompress(r.take)).to eq('abc')
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
This patch will add feature to support Ractor which was introduced at Ruby 3.0.

Ref. https://techlife.cookpad.com/entry/2020/12/26/131858