### PR TITLE
Feature/unlock gvl for streaming compression/decompression

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,11 +7,20 @@
 
 name: Ruby
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/benchmarks/multi_thread_comporess.rb
+++ b/benchmarks/multi_thread_comporess.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'objspace'
 require 'zstd-ruby'
 require 'thread'
+require "zstds"
 
 GUESSES = (ENV['GUESSES'] || 1000).to_i
 THREADS = (ENV['THREADS'] || 1).to_i
@@ -14,19 +15,14 @@ sample_file_name = ARGV[0]
 json_string = File.read("./samples/#{sample_file_name}")
 
 queue = Queue.new
-# queue = []
 GUESSES.times { queue << json_string }
-# stream = Zstd::StreamingCompress.new(thread_num: THREADS)
 THREADS.times { queue << nil }
 THREADS.times.map {
   Thread.new {
     while str = queue.pop
-      # stream = Zstd::StreamingCompress.new(thread_num: THREADS)
-      #stream << str
-      #stream << str
-      #stream << str
-      #stream.flush
-      Zstd.compress(str, thread_num: 1)
+      stream = Zstd::StreamingCompress.new
+      stream << str
+      stream.finish
     end
   }
 }.each(&:join)

--- a/benchmarks/multi_thread_comporess.rb
+++ b/benchmarks/multi_thread_comporess.rb
@@ -14,12 +14,19 @@ sample_file_name = ARGV[0]
 json_string = File.read("./samples/#{sample_file_name}")
 
 queue = Queue.new
+# queue = []
 GUESSES.times { queue << json_string }
+# stream = Zstd::StreamingCompress.new(thread_num: THREADS)
 THREADS.times { queue << nil }
 THREADS.times.map {
   Thread.new {
     while str = queue.pop
-      Zstd.compress(str)
+      # stream = Zstd::StreamingCompress.new(thread_num: THREADS)
+      #stream << str
+      #stream << str
+      #stream << str
+      #stream.flush
+      Zstd.compress(str, thread_num: 1)
     end
   }
 }.each(&:join)

--- a/benchmarks/multi_thread_streaming_comporess.rb
+++ b/benchmarks/multi_thread_streaming_comporess.rb
@@ -1,7 +1,4 @@
-require 'benchmark/ips'
 $LOAD_PATH.unshift '../lib'
-require 'json'
-require 'objspace'
 require 'zstd-ruby'
 require 'thread'
 

--- a/benchmarks/multi_thread_streaming_comporess.rb
+++ b/benchmarks/multi_thread_streaming_comporess.rb
@@ -1,0 +1,29 @@
+require 'benchmark/ips'
+$LOAD_PATH.unshift '../lib'
+require 'json'
+require 'objspace'
+require 'zstd-ruby'
+require 'thread'
+
+GUESSES = (ENV['GUESSES'] || 1000).to_i
+THREADS = (ENV['THREADS'] || 1).to_i
+
+p GUESSES: GUESSES, THREADS: THREADS
+
+sample_file_name = ARGV[0]
+json_string = File.read("./samples/#{sample_file_name}")
+
+queue = Queue.new
+GUESSES.times { queue << json_string }
+THREADS.times { queue << nil }
+THREADS.times.map {
+  Thread.new {
+    while str = queue.pop
+      stream = Zstd::StreamingCompress.new
+      stream << str
+      res = stream.flush
+      stream << str
+      res << stream.finish
+    end
+  }
+}.each(&:join)

--- a/benchmarks/multi_thread_streaming_decomporess.rb
+++ b/benchmarks/multi_thread_streaming_decomporess.rb
@@ -1,7 +1,4 @@
-require 'benchmark/ips'
 $LOAD_PATH.unshift '../lib'
-require 'json'
-require 'objspace'
 require 'zstd-ruby'
 require 'thread'
 

--- a/benchmarks/zstd_compress_memory.rb
+++ b/benchmarks/zstd_compress_memory.rb
@@ -10,7 +10,7 @@ p "#{ObjectSpace.memsize_of_all/1000} #{ObjectSpace.count_objects} #{`ps -o rss=
 
 sample_file_name = ARGV[0]
 
-json_data = JSON.parse(IO.read("./samples/#{sample_file_name}"), symbolize_names: true)
+json_data = JSON.parse(File.read("./samples/#{sample_file_name}"), symbolize_names: true)
 json_string = json_data.to_json
 
 i = 0

--- a/benchmarks/zstd_decompress_memory.rb
+++ b/benchmarks/zstd_decompress_memory.rb
@@ -9,7 +9,7 @@ require 'objspace'
 p "#{ObjectSpace.memsize_of_all/1000} #{ObjectSpace.count_objects} #{`ps -o rss= -p #{Process.pid}`.to_i}"
 
 sample_file_name = ARGV[0]
-json_data = JSON.parse(IO.read("./samples/#{sample_file_name}"), symbolize_names: true)
+json_data = JSON.parse(File.read("./samples/#{sample_file_name}"), symbolize_names: true)
 json_string = json_data.to_json
 
 i = 0

--- a/benchmarks/zstd_streaming_compress_memory.rb
+++ b/benchmarks/zstd_streaming_compress_memory.rb
@@ -10,7 +10,7 @@ p "#{ObjectSpace.memsize_of_all/1000} #{ObjectSpace.count_objects} #{`ps -o rss=
 
 sample_file_name = ARGV[0]
 
-json_string = IO.read("./samples/#{sample_file_name}")
+json_string = File.read("./samples/#{sample_file_name}")
 
 i = 0
 start_time = Time.now

--- a/benchmarks/zstd_streaming_decompress_memory.rb
+++ b/benchmarks/zstd_streaming_decompress_memory.rb
@@ -10,7 +10,7 @@ p "#{ObjectSpace.memsize_of_all/1000} #{ObjectSpace.count_objects} #{`ps -o rss=
 
 sample_file_name = ARGV[0]
 
-cstr = IO.read("./results/#{sample_file_name}.zstd")
+cstr = File.read("./results/#{sample_file_name}.zstd")
 i = 0
 start_time = Time.now
 while true do

--- a/examples/sinatra/Gemfile.lock
+++ b/examples/sinatra/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    zstd-ruby (1.5.6.1)
+    zstd-ruby (1.5.6.2)
 
 GEM
   remote: https://rubygems.org/

--- a/ext/zstdruby/common.h
+++ b/ext/zstdruby/common.h
@@ -5,6 +5,7 @@
 #ifdef HAVE_RUBY_THREAD_H
 #include <ruby/thread.h>
 #endif
+#include <stdbool.h>
 #include "./libzstd/zstd.h"
 
 static int convert_compression_level(VALUE compression_level_value)

--- a/ext/zstdruby/common.h
+++ b/ext/zstdruby/common.h
@@ -43,12 +43,11 @@ static size_t zstd_compress(ZSTD_CCtx* const ctx, ZSTD_outBuffer* output, ZSTD_i
 
 static void set_compress_params(ZSTD_CCtx* const ctx, VALUE level_from_args, VALUE kwargs)
 {
-  ID kwargs_keys[3];
+  ID kwargs_keys[2];
   kwargs_keys[0] = rb_intern("level");
   kwargs_keys[1] = rb_intern("dict");
-  kwargs_keys[2] = rb_intern("thread_num");
-  VALUE kwargs_values[3];
-  rb_get_kwargs(kwargs, kwargs_keys, 0, 3, kwargs_values);
+  VALUE kwargs_values[2];
+  rb_get_kwargs(kwargs, kwargs_keys, 0, 2, kwargs_values);
 
   int compression_level = ZSTD_CLEVEL_DEFAULT;
   if (kwargs_values[0] != Qundef && kwargs_values[0] != Qnil) {
@@ -67,15 +66,6 @@ static void set_compress_params(ZSTD_CCtx* const ctx, VALUE level_from_args, VAL
       ZSTD_freeCCtx(ctx);
       rb_raise(rb_eRuntimeError, "%s", "ZSTD_CCtx_loadDictionary failed");
     }
-  }
-
-  if (kwargs_values[2] != Qundef && kwargs_values[2] != Qnil) {
-    int thread_num = NUM2INT(kwargs_values[2]);
-    size_t const r = ZSTD_CCtx_setParameter(ctx, ZSTD_c_nbWorkers, thread_num);
-    if (ZSTD_isError(r)) {
-      rb_warn("Note: the linked libzstd library doesn't support multithreading.Reverting to single-thread mode. \n");
-    }
-    // ZSTD_CCtx_setParameter(ctx, ZSTD_c_jobSize, thread_num);
   }
 }
 

--- a/ext/zstdruby/common.h
+++ b/ext/zstdruby/common.h
@@ -2,6 +2,9 @@
 #define ZSTD_RUBY_H 1
 
 #include <ruby.h>
+#ifdef HAVE_RUBY_THREAD_H
+#include <ruby/thread.h>
+#endif
 #include "./libzstd/zstd.h"
 
 static int convert_compression_level(VALUE compression_level_value)
@@ -12,18 +15,40 @@ static int convert_compression_level(VALUE compression_level_value)
   return NUM2INT(compression_level_value);
 }
 
+struct compress_params {
+  ZSTD_CCtx* ctx;
+  ZSTD_outBuffer* output;
+  ZSTD_inBuffer* input;
+  ZSTD_EndDirective endOp;
+  size_t ret;
+};
+
+static void* compress_wrapper(void* args)
+{
+    struct compress_params* params = args;
+    params->ret = ZSTD_compressStream2(params->ctx, params->output, params->input, params->endOp);
+    return NULL;
+}
+
 static size_t zstd_compress(ZSTD_CCtx* const ctx, ZSTD_outBuffer* output, ZSTD_inBuffer* input, ZSTD_EndDirective endOp)
 {
-  return ZSTD_compressStream2(ctx, output, input, endOp);
+#ifdef HAVE_RUBY_THREAD_H
+    struct compress_params params = { ctx, output, input, endOp };
+    rb_thread_call_without_gvl(compress_wrapper, &params, RUBY_UBF_IO, NULL);
+    return params.ret;
+#else
+    return ZSTD_compressStream2(ctx, output, input, endOp);
+#endif
 }
 
 static void set_compress_params(ZSTD_CCtx* const ctx, VALUE level_from_args, VALUE kwargs)
 {
-  ID kwargs_keys[2];
+  ID kwargs_keys[3];
   kwargs_keys[0] = rb_intern("level");
   kwargs_keys[1] = rb_intern("dict");
-  VALUE kwargs_values[2];
-  rb_get_kwargs(kwargs, kwargs_keys, 0, 2, kwargs_values);
+  kwargs_keys[2] = rb_intern("thread_num");
+  VALUE kwargs_values[3];
+  rb_get_kwargs(kwargs, kwargs_keys, 0, 3, kwargs_values);
 
   int compression_level = ZSTD_CLEVEL_DEFAULT;
   if (kwargs_values[0] != Qundef && kwargs_values[0] != Qnil) {
@@ -42,6 +67,15 @@ static void set_compress_params(ZSTD_CCtx* const ctx, VALUE level_from_args, VAL
       ZSTD_freeCCtx(ctx);
       rb_raise(rb_eRuntimeError, "%s", "ZSTD_CCtx_loadDictionary failed");
     }
+  }
+
+  if (kwargs_values[2] != Qundef && kwargs_values[2] != Qnil) {
+    int thread_num = NUM2INT(kwargs_values[2]);
+    size_t const r = ZSTD_CCtx_setParameter(ctx, ZSTD_c_nbWorkers, thread_num);
+    if (ZSTD_isError(r)) {
+      rb_warn("Note: the linked libzstd library doesn't support multithreading.Reverting to single-thread mode. \n");
+    }
+    // ZSTD_CCtx_setParameter(ctx, ZSTD_c_jobSize, thread_num);
   }
 }
 

--- a/ext/zstdruby/extconf.rb
+++ b/ext/zstdruby/extconf.rb
@@ -2,7 +2,7 @@ require "mkmf"
 
 have_func('rb_gc_mark_movable')
 
-$CFLAGS = '-I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY -DZSTD_MULTITHREAD -pthread'
+$CFLAGS = '-I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY -DZSTD_MULTITHREAD -pthread -DDEBUGLEVEL=0'
 $CPPFLAGS += " -fdeclspec" if CONFIG['CXX'] =~ /clang/
 
 Dir.chdir File.expand_path('..', __FILE__) do

--- a/ext/zstdruby/extconf.rb
+++ b/ext/zstdruby/extconf.rb
@@ -2,7 +2,7 @@ require "mkmf"
 
 have_func('rb_gc_mark_movable')
 
-$CFLAGS = '-I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY'
+$CFLAGS = '-I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY -DZSTD_MULTITHREAD -pthread'
 $CPPFLAGS += " -fdeclspec" if CONFIG['CXX'] =~ /clang/
 
 Dir.chdir File.expand_path('..', __FILE__) do

--- a/ext/zstdruby/streaming_compress.c
+++ b/ext/zstdruby/streaming_compress.c
@@ -106,7 +106,7 @@ no_compress(struct streaming_compress_t* sc, ZSTD_EndDirective endOp)
   do {
     ZSTD_outBuffer output = { (void*)output_data, sc->buf_size, 0 };
 
-    size_t const ret = zstd_compress(sc->ctx, &output, &input, endOp);
+    size_t const ret = zstd_compress(sc->ctx, &output, &input, endOp, false);
     if (ZSTD_isError(ret)) {
       rb_raise(rb_eRuntimeError, "flush error error code: %s", ZSTD_getErrorName(ret));
     }
@@ -130,7 +130,7 @@ rb_streaming_compress_compress(VALUE obj, VALUE src)
   VALUE result = rb_str_new(0, 0);
   while (input.pos < input.size) {
     ZSTD_outBuffer output = { (void*)output_data, sc->buf_size, 0 };
-    size_t const ret = zstd_compress(sc->ctx, &output, &input, ZSTD_e_continue);
+    size_t const ret = zstd_compress(sc->ctx, &output, &input, ZSTD_e_continue, false);
     if (ZSTD_isError(ret)) {
       rb_raise(rb_eRuntimeError, "compress error error code: %s", ZSTD_getErrorName(ret));
     }
@@ -157,7 +157,7 @@ rb_streaming_compress_write(int argc, VALUE *argv, VALUE obj)
 
     while (input.pos < input.size) {
       ZSTD_outBuffer output = { (void*)output_data, sc->buf_size, 0 };
-      size_t const ret = zstd_compress(sc->ctx, &output, &input, ZSTD_e_continue);
+      size_t const ret = zstd_compress(sc->ctx, &output, &input, ZSTD_e_continue, false);
       if (ZSTD_isError(ret)) {
         rb_raise(rb_eRuntimeError, "compress error error code: %s", ZSTD_getErrorName(ret));
       }

--- a/ext/zstdruby/streaming_decompress.c
+++ b/ext/zstdruby/streaming_decompress.c
@@ -104,7 +104,7 @@ rb_streaming_decompress_decompress(VALUE obj, VALUE src)
   VALUE result = rb_str_new(0, 0);
   while (input.pos < input.size) {
     ZSTD_outBuffer output = { (void*)output_data, sd->buf_size, 0 };
-    size_t const ret = ZSTD_decompressStream(sd->dctx, &output, &input);
+    size_t const ret = zstd_decompress(sd->dctx, &output, &input);
     if (ZSTD_isError(ret)) {
       rb_raise(rb_eRuntimeError, "decompress error error code: %s", ZSTD_getErrorName(ret));
     }

--- a/ext/zstdruby/streaming_decompress.c
+++ b/ext/zstdruby/streaming_decompress.c
@@ -104,7 +104,7 @@ rb_streaming_decompress_decompress(VALUE obj, VALUE src)
   VALUE result = rb_str_new(0, 0);
   while (input.pos < input.size) {
     ZSTD_outBuffer output = { (void*)output_data, sd->buf_size, 0 };
-    size_t const ret = zstd_decompress(sd->dctx, &output, &input);
+    size_t const ret = zstd_decompress(sd->dctx, &output, &input, false);
     if (ZSTD_isError(ret)) {
       rb_raise(rb_eRuntimeError, "decompress error error code: %s", ZSTD_getErrorName(ret));
     }

--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -99,7 +99,7 @@ static VALUE decompress_buffered(ZSTD_DCtx* dctx, const char* input_data, size_t
     rb_str_resize(output_string, output.size);
     output.dst = RSTRING_PTR(output_string);
 
-    size_t ret = ZSTD_decompressStream(dctx, &output, &input);
+    size_t ret = zstd_decompress(dctx, &output, &input);
     if (ZSTD_isError(ret)) {
       ZSTD_freeDCtx(dctx);
       rb_raise(rb_eRuntimeError, "%s: %s", "ZSTD_decompressStream failed", ZSTD_getErrorName(ret));

--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -32,7 +32,7 @@ static VALUE rb_compress(int argc, VALUE *argv, VALUE self)
   char* output_data = RSTRING_PTR(buf);
   ZSTD_outBuffer output = { (void*)output_data, max_compressed_size, 0 };
 
-  size_t const ret = zstd_compress(ctx, &output, &input, ZSTD_e_end);
+  size_t const ret = zstd_compress(ctx, &output, &input, ZSTD_e_end, true);
   if (ZSTD_isError(ret)) {
     ZSTD_freeCCtx(ctx);
     rb_raise(rb_eRuntimeError, "%s: %s", "compress failed", ZSTD_getErrorName(ret));
@@ -99,7 +99,7 @@ static VALUE decompress_buffered(ZSTD_DCtx* dctx, const char* input_data, size_t
     rb_str_resize(output_string, output.size);
     output.dst = RSTRING_PTR(output_string);
 
-    size_t ret = zstd_decompress(dctx, &output, &input);
+    size_t ret = zstd_decompress(dctx, &output, &input, true);
     if (ZSTD_isError(ret)) {
       ZSTD_freeDCtx(dctx);
       rb_raise(rb_eRuntimeError, "%s: %s", "ZSTD_decompressStream failed", ZSTD_getErrorName(ret));

--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -26,6 +26,7 @@ static VALUE rb_compress(int argc, VALUE *argv, VALUE self)
   char* input_data = RSTRING_PTR(input_value);
   size_t input_size = RSTRING_LEN(input_value);
   ZSTD_inBuffer input = { input_data, input_size, 0 };
+  // ZSTD_compressBound causes SEGV under multi-thread
   size_t max_compressed_size = ZSTD_compressBound(input_size);
   VALUE buf = rb_str_new(NULL, max_compressed_size);
   char* output_data = RSTRING_PTR(buf);
@@ -87,19 +88,8 @@ static VALUE rb_compress_using_dict(int argc, VALUE *argv, VALUE self)
 }
 
 
-static VALUE decompress_buffered(const char* input_data, size_t input_size)
+static VALUE decompress_buffered(ZSTD_DCtx* dctx, const char* input_data, size_t input_size)
 {
-  ZSTD_DStream* const dstream = ZSTD_createDStream();
-  if (dstream == NULL) {
-    rb_raise(rb_eRuntimeError, "%s", "ZSTD_createDStream failed");
-  }
-
-  size_t initResult = ZSTD_initDStream(dstream);
-  if (ZSTD_isError(initResult)) {
-    ZSTD_freeDStream(dstream);
-    rb_raise(rb_eRuntimeError, "%s: %s", "ZSTD_initDStream failed", ZSTD_getErrorName(initResult));
-  }
-
   VALUE output_string = rb_str_new(NULL, 0);
   ZSTD_outBuffer output = { NULL, 0, 0 };
 
@@ -109,15 +99,14 @@ static VALUE decompress_buffered(const char* input_data, size_t input_size)
     rb_str_resize(output_string, output.size);
     output.dst = RSTRING_PTR(output_string);
 
-    size_t readHint = ZSTD_decompressStream(dstream, &output, &input);
-    if (ZSTD_isError(readHint)) {
-      ZSTD_freeDStream(dstream);
-      rb_raise(rb_eRuntimeError, "%s: %s", "ZSTD_decompressStream failed", ZSTD_getErrorName(readHint));
+    size_t ret = ZSTD_decompressStream(dctx, &output, &input);
+    if (ZSTD_isError(ret)) {
+      ZSTD_freeDCtx(dctx);
+      rb_raise(rb_eRuntimeError, "%s: %s", "ZSTD_decompressStream failed", ZSTD_getErrorName(ret));
     }
   }
-
-  ZSTD_freeDStream(dstream);
   rb_str_resize(output_string, output.pos);
+  ZSTD_freeDCtx(dctx);
   return output_string;
 }
 
@@ -129,6 +118,11 @@ static VALUE rb_decompress(int argc, VALUE *argv, VALUE self)
   StringValue(input_value);
   char* input_data = RSTRING_PTR(input_value);
   size_t input_size = RSTRING_LEN(input_value);
+  ZSTD_DCtx* const dctx = ZSTD_createDCtx();
+  if (dctx == NULL) {
+    rb_raise(rb_eRuntimeError, "%s", "ZSTD_createDCtx failed");
+  }
+  set_decompress_params(dctx, kwargs);
 
   unsigned long long const uncompressed_size = ZSTD_getFrameContentSize(input_data, input_size);
   if (uncompressed_size == ZSTD_CONTENTSIZE_ERROR) {
@@ -137,14 +131,8 @@ static VALUE rb_decompress(int argc, VALUE *argv, VALUE self)
   // ZSTD_decompressStream may be called multiple times when ZSTD_CONTENTSIZE_UNKNOWN, causing slowness.
   // Therefore, we will not standardize on ZSTD_decompressStream
   if (uncompressed_size == ZSTD_CONTENTSIZE_UNKNOWN) {
-    return decompress_buffered(input_data, input_size);
+    return decompress_buffered(dctx, input_data, input_size);
   }
-
-  ZSTD_DCtx* const dctx = ZSTD_createDCtx();
-  if (dctx == NULL) {
-    rb_raise(rb_eRuntimeError, "%s", "ZSTD_createDCtx failed");
-  }
-  set_decompress_params(dctx, kwargs);
 
   VALUE output = rb_str_new(NULL, uncompressed_size);
   char* output_data = RSTRING_PTR(output);
@@ -167,15 +155,6 @@ static VALUE rb_decompress_using_dict(int argc, VALUE *argv, VALUE self)
   StringValue(input_value);
   char* input_data = RSTRING_PTR(input_value);
   size_t input_size = RSTRING_LEN(input_value);
-  unsigned long long const uncompressed_size = ZSTD_getFrameContentSize(input_data, input_size);
-  if (uncompressed_size == ZSTD_CONTENTSIZE_ERROR) {
-    rb_raise(rb_eRuntimeError, "%s: %s", "not compressed by zstd", ZSTD_getErrorName(uncompressed_size));
-  }
-  if (uncompressed_size == ZSTD_CONTENTSIZE_UNKNOWN) {
-    return decompress_buffered(input_data, input_size);
-  }
-  VALUE output = rb_str_new(NULL, uncompressed_size);
-  char* output_data = RSTRING_PTR(output);
 
   char* dict_buffer = RSTRING_PTR(dict);
   size_t dict_size = RSTRING_LEN(dict);
@@ -183,12 +162,11 @@ static VALUE rb_decompress_using_dict(int argc, VALUE *argv, VALUE self)
   if (ddict == NULL) {
     rb_raise(rb_eRuntimeError, "%s", "ZSTD_createDDict failed");
   }
-
   unsigned const expected_dict_id = ZSTD_getDictID_fromDDict(ddict);
   unsigned const actual_dict_id = ZSTD_getDictID_fromFrame(input_data, input_size);
   if (expected_dict_id != actual_dict_id) {
     ZSTD_freeDDict(ddict);
-    rb_raise(rb_eRuntimeError, "%s: %s", "DictID mismatch", ZSTD_getErrorName(uncompressed_size));
+    rb_raise(rb_eRuntimeError, "DictID mismatch");
   }
 
   ZSTD_DCtx* const ctx = ZSTD_createDCtx();
@@ -196,6 +174,19 @@ static VALUE rb_decompress_using_dict(int argc, VALUE *argv, VALUE self)
     ZSTD_freeDDict(ddict);
     rb_raise(rb_eRuntimeError, "%s", "ZSTD_createDCtx failed");
   }
+
+  unsigned long long const uncompressed_size = ZSTD_getFrameContentSize(input_data, input_size);
+  if (uncompressed_size == ZSTD_CONTENTSIZE_ERROR) {
+    ZSTD_freeDDict(ddict);
+    ZSTD_freeDCtx(ctx);
+    rb_raise(rb_eRuntimeError, "%s: %s", "not compressed by zstd", ZSTD_getErrorName(uncompressed_size));
+  }
+  if (uncompressed_size == ZSTD_CONTENTSIZE_UNKNOWN) {
+    return decompress_buffered(ctx, input_data, input_size);
+  }
+
+  VALUE output = rb_str_new(NULL, uncompressed_size);
+  char* output_data = RSTRING_PTR(output);
   size_t const decompress_size = ZSTD_decompress_usingDDict(ctx, output_data, uncompressed_size, input_data, input_size, ddict);
   if (ZSTD_isError(decompress_size)) {
     ZSTD_freeDDict(ddict);


### PR DESCRIPTION
Zstd streaming compression/decompression is a CPU-only process that do not involve the ruby interpreter.
Therefore, it is possible to unlock the GVL, allowing for parallel multiple threads, thus fully utilizing CPU resources.

This program demonstrates the difference:
(in `benckmarks`)

Re-introduce https://github.com/SpringMT/zstd-ruby/pull/53

## Streaming Compression

```ruby
$LOAD_PATH.unshift '../lib'
require 'zstd-ruby'
require 'thread'

GUESSES = (ENV['GUESSES'] || 1000).to_i
THREADS = (ENV['THREADS'] || 1).to_i

p GUESSES: GUESSES, THREADS: THREADS

sample_file_name = ARGV[0]
json_string = File.read("./samples/#{sample_file_name}")

queue = Queue.new
GUESSES.times { queue << json_string }
THREADS.times { queue << nil }
THREADS.times.map {
  Thread.new {
    while str = queue.pop
      stream = Zstd::StreamingCompress.new
      stream << str
      res = stream.flush
      stream << str
      res << stream.finish
    end
  }
}.each(&:join)
```

Without this patch:

```
[springmt@MacBook-Pro] (main)✗ % time THREADS=4 bundle exec ruby multi_thread_streaming_comporess.rb city.json
{:GUESSES=>1000, :THREADS=>4}
THREADS=4 bundle exec ruby multi_thread_streaming_comporess.rb city.json  2.83s user 0.29s system 94% cpu 3.299 total
```

With the patch:

```
[springmt@MacBook-Pro] (feature/unlock-gvl)✗ % time THREADS=4 bundle exec ruby multi_thread_streaming_comporess.rb city.json
{:GUESSES=>1000, :THREADS=>4}
THREADS=4 bundle exec ruby multi_thread_streaming_comporess.rb city.json  3.33s user 0.36s system 266% cpu 1.385 total
```

## Streaming Decompression

```ruby
$LOAD_PATH.unshift '../lib'
require 'zstd-ruby'
require 'thread'

GUESSES = (ENV['GUESSES'] || 1000).to_i
THREADS = (ENV['THREADS'] || 1).to_i

p GUESSES: GUESSES, THREADS: THREADS

sample_file_name = ARGV[0]
json_string = File.read("./samples/#{sample_file_name}")
target = Zstd.compress(json_string)

queue = Queue.new
GUESSES.times { queue << target }
THREADS.times { queue << nil }
THREADS.times.map {
  Thread.new {
    while str = queue.pop
      stream = Zstd::StreamingDecompress.new
      stream.decompress(str)
      stream.decompress(str)
    end
  }
}.each(&:join)
```

Without this patch:

```
[springmt@MacBook-Pro] (main)✗ % time THREADS=4 bundle exec ruby multi_thread_streaming_decomporess.rb city.json
{:GUESSES=>1000, :THREADS=>4}
THREADS=4 bundle exec ruby multi_thread_streaming_decomporess.rb city.json  2.03s user 0.28s system 93% cpu 2.486 total
```


With the patch:

```
[springmt@MacBook-Pro] (feature/unlock-gvl)✗ % time THREADS=4 bundle exec ruby multi_thread_streaming_decomporess.rb city.json
{:GUESSES=>1000, :THREADS=>4}
THREADS=4 bundle exec ruby multi_thread_streaming_decomporess.rb city.json  2.49s user 0.49s system 227% cpu 1.310 total
```


