### PR TITLE
Fix deprecation warning in StreamWriter

### DIFF
--- a/lib/zstd-ruby/stream_writer.rb
+++ b/lib/zstd-ruby/stream_writer.rb
@@ -3,7 +3,7 @@ module Zstd
   class StreamWriter
     def initialize(io, level: nil)
       @io = io
-      @stream = Zstd::StreamingCompress.new(level)
+      @stream = Zstd::StreamingCompress.new(level: level)
     end
 
     def write(*data)

--- a/spec/zstd-ruby-stream_writer_spec.rb
+++ b/spec/zstd-ruby-stream_writer_spec.rb
@@ -13,4 +13,14 @@ RSpec.describe Zstd::StreamWriter do
       expect(Zstd.decompress(io.read)).to eq('abcdef')
     end
   end
+  describe 'level' do
+    it 'should work' do
+      io = StringIO.new
+      stream = Zstd::StreamWriter.new(io, level: 5)
+      stream.write("abcdef")
+      stream.finish
+      io.rewind
+      expect(Zstd.decompress(io.read)).to eq('abcdef')
+    end
+  end
 end


### PR DESCRIPTION
Fixes this warning:
```
gems/zstd-ruby-1.5.6.6/lib/zstd-ruby/stream_writer.rb:6: warning: `level` in args is deprecated; use keyword args `level:` instead.
```
