### PR TITLE
feat: support CDict & DDict for faster operation with repeated dictionary use

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ compressed_data = Zstd.compress(data, level: complession_level) # default compre
 compressed_using_dict = Zstd.compress("", dict: File.read('dictionary_file'))
 ```
 
+#### Compression with CDict
+
+If you use the same dictionary repeatedly, you can speed up the setup by creating CDict in advance:
+
+```ruby
+cdict = Zstd::CDict.new(File.read('dictionary_file'))
+compressed_using_dict = Zstd.compress("", dict: cdict)
+```
+
+The compression_level can be specified on creating CDict.
+
+```ruby
+cdict = Zstd::CDict.new(File.read('dictionary_file'), 5)
+compressed_using_dict = Zstd.compress("", dict: cdict)
+```
+
 #### Streaming Compression
 ```ruby
 stream = Zstd::StreamingCompress.new
@@ -86,6 +102,16 @@ stream << "ghi"
 res << stream.finish
 ```
 
+#### Streaming Compression with CDict of level 5
+```ruby
+cdict = Zstd::CDict.new(File.read('dictionary_file', 5)
+stream = Zstd::StreamingCompress.new(dict: cdict)
+stream << "abc" << "def"
+res = stream.flush
+stream << "ghi"
+res << stream.finish
+```
+
 ### Decompression
 
 #### Simple Decompression
@@ -98,6 +124,15 @@ data = Zstd.decompress(compressed_data)
 ```ruby
 # dictionary is supposed to have been created using `zstd --train`
 Zstd.decompress(compressed_using_dict, dict: File.read('dictionary_file'))
+```
+
+#### Decompression with DDict
+
+If you use the same dictionary repeatedly, you can speed up the setup by creating DDict in advance:
+
+```ruby
+cdict = Zstd::CDict.new(File.read('dictionary_file'))
+compressed_using_dict = Zstd.compress(compressed_using_dict, ddict)
 ```
 
 #### Streaming Decompression
@@ -117,6 +152,8 @@ result = ''
 result << stream.decompress(cstr[0, 10])
 result << stream.decompress(cstr[10..-1])
 ```
+
+DDict can also be specified to `dict:`.
 
 ### Skippable frame
 

--- a/ext/zstdruby/main.c
+++ b/ext/zstdruby/main.c
@@ -1,6 +1,8 @@
 #include "common.h"
 
 VALUE rb_mZstd;
+VALUE rb_cCDict;
+VALUE rb_cDDict;
 void zstd_ruby_init(void);
 void zstd_ruby_skippable_frame_init(void);
 void zstd_ruby_streaming_compress_init(void);
@@ -14,6 +16,8 @@ Init_zstdruby(void)
 #endif
 
   rb_mZstd = rb_define_module("Zstd");
+  rb_cCDict = rb_define_class_under(rb_mZstd, "CDict", rb_cObject);
+  rb_cDDict = rb_define_class_under(rb_mZstd, "DDict", rb_cObject);
   zstd_ruby_init();
   zstd_ruby_skippable_frame_init();
   zstd_ruby_streaming_compress_init();

--- a/spec/zstd-ruby-streaming-compress_spec.rb
+++ b/spec/zstd-ruby-streaming-compress_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Zstd::StreamingCompress do
     end
   end
 
-  describe 'dictionary' do
+  describe 'String dictionary' do
     let(:dictionary) do
       File.read("#{__dir__}/dictionary")
     end
@@ -62,6 +62,25 @@ RSpec.describe Zstd::StreamingCompress do
     end
     it 'shoud work' do
       dict_stream = Zstd::StreamingCompress.new(level: 5, dict: dictionary)
+      dict_stream << user_json
+      dict_res = dict_stream.finish
+      stream = Zstd::StreamingCompress.new(level: 5)
+      stream << user_json
+      res = stream.finish
+
+      expect(dict_res.length).to be < res.length
+    end
+  end
+
+  describe 'Zstd::CDict dictionary' do
+    let(:cdict) do
+      Zstd::CDict.new(File.read("#{__dir__}/dictionary"), 5)
+    end
+    let(:user_json) do
+      File.read("#{__dir__}/user_springmt.json")
+    end
+    it 'shoud work' do
+      dict_stream = Zstd::StreamingCompress.new(dict: cdict)
       dict_stream << user_json
       dict_res = dict_stream.finish
       stream = Zstd::StreamingCompress.new(level: 5)


### PR DESCRIPTION
Currently the dictionary is setup every time when it is passed to compress(dict:) / decompress(dict:), but the dictionary setup is costly process.
When the dictionary is repeatedly used, creating CDict / DDict in advance makes the compression / decompression much efficient.
This adds the `Zstd::CDict` & `Zstd::DDict` class to manage pre-loaded dictionary references.

### Benchmark
CDict makes it x~13 times faster to compress `spec/user_springmt.json` 100 times with `spec/dictionary`.
```
                               user     system      total        real
compress with String dict  0.012185   0.001020   0.013205 (  0.013205)
compress with CDict        0.000927   0.000040   0.000967 (  0.000973)
```

```ruby
require 'bundler/setup'
require 'zstd-ruby'
require 'benchmark'

data = IO.read("spec/user_springmt.json")
dict = IO.read("spec/dictionary")
cdict = Zstd::CDict.new(dict, 6)
ddict = Zstd::DDict.new(dict)

Benchmark.bm 24 do |x|
  x.report("compress with String dict") do
    100.times { Zstd.compress(data, dict: dict) }
  end
  x.report("compress with CDict") do
    100.times { Zstd.compress(data, dict: cdict) }
  end
end
```