### PR TITLE
fix: missing argument names in rb_prohibit_copy (build failure on older GCC/Clang)

### DIFF
--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -274,7 +274,7 @@ static VALUE rb_ddict_initialize(VALUE self, VALUE dict)
   return self;
 }
 
-static VALUE rb_prohibit_copy(VALUE, VALUE)
+static VALUE rb_prohibit_copy(VALUE self, VALUE obj)
 {
   rb_raise(rb_eRuntimeError, "CDict cannot be duplicated");
 }


### PR DESCRIPTION
The argument variable names of `rb_prohibit_copy` introduced in [#98](https://github.com/SpringMT/zstd-ruby/pull/98) are missing.
This is C23-style function declarations (N2480), so it causes build failures on older versions of GCC <= 10 (and Clang <= 10) [^1] with the following error:

```
compiling main.c
compiling skippable_frame.c
compiling streaming_compress.c
compiling streaming_decompress.c
compiling zstdruby.c
zstdruby.c: In function ‘rb_prohibit_copy’:
zstdruby.c:277:31: error: parameter name omitted
  277 | static VALUE rb_prohibit_copy(VALUE, VALUE)
      |                               ^~~~~
zstdruby.c:277:38: error: parameter name omitted
  277 | static VALUE rb_prohibit_copy(VALUE, VALUE)
      |                                      ^~~~~
make: *** [Makefile:248: zstdruby.o] Error 1

make failed, exit code 2
```

Although this error does not occur on recent versions of GCC/Clang, it may cause build failures in slightly older environments.
This PR fixes the function declaration by explicitly specifying the argument variable names to maintain compatibility.

[^1]: https://en.cppreference.com/w/c/23