### PR TITLE
Fix build error with GCC 15

### DIFF
--- a/ext/zstdruby/common.h
+++ b/ext/zstdruby/common.h
@@ -1,11 +1,11 @@
 #ifndef ZSTD_RUBY_H
 #define ZSTD_RUBY_H 1
 
+#include <stdbool.h>
 #include <ruby.h>
 #ifdef HAVE_RUBY_THREAD_H
 #include <ruby/thread.h>
 #endif
-#include <stdbool.h>
 #include "./libzstd/zstd.h"
 
 extern VALUE rb_cCDict, rb_cDDict;


### PR DESCRIPTION
This PR will fix build error with GCC 15

### Environment
Use docker environment.
```
FROM archlinux:latest

RUN pacman -Syu --noconfirm && \
    pacman -S --noconfirm base-devel curl git rust openssl zlib libffi libyaml
RUN curl -O https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.4.tar.gz && \
    tar -xzf ruby-3.4.4.tar.gz && \
    cd ruby-3.4.4 && \
    ./configure --disable-install-doc && \
    make -j && \
    make install
```

### How to reproduce
Build docker image and run.
```
$ docker build -t ruby .
$ docker run --rm -it ruby bash
[root@308887526a8d /]# gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/15.1.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 15.1.1 20250425 (GCC)

[root@308887526a8d /]# ruby -v
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [x86_64-linux]

[root@22e9fc547060 ~]# gem install zstd-ruby
Building native extensions. This could take a while...
ERROR:  Error installing zstd-ruby:
        ERROR: Failed to build gem native extension.

    current directory: /usr/local/lib/ruby/gems/3.4.0/gems/zstd-ruby-1.5.6.6/ext/zstdruby
/usr/local/bin/ruby extconf.rb
checking for rb_gc_mark_movable()... yes
creating Makefile

current directory: /usr/local/lib/ruby/gems/3.4.0/gems/zstd-ruby-1.5.6.6/ext/zstdruby
make DESTDIR\= sitearchdir\=./.gem.20250608-535-cg5j40 sitelibdir\=./.gem.20250608-535-cg5j40 clean

current directory: /usr/local/lib/ruby/gems/3.4.0/gems/zstd-ruby-1.5.6.6/ext/zstdruby
make DESTDIR\= sitearchdir\=./.gem.20250608-535-cg5j40 sitelibdir\=./.gem.20250608-535-cg5j40
compiling ./libzstd/common/debug.c
compiling ./libzstd/common/entropy_common.c
compiling ./libzstd/common/error_private.c
compiling ./libzstd/common/fse_decompress.c
compiling ./libzstd/common/pool.c
In file included from ./libzstd/common/pool.c:13:
./libzstd/common/../common/allocations.h:18:9: warning: ‘ZSTD_STATIC_LINKING_ONLY’ redefined
   18 | #define ZSTD_STATIC_LINKING_ONLY
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
compiling ./libzstd/common/threading.c
compiling ./libzstd/common/xxhash.c
compiling ./libzstd/common/zstd_common.c
In file included from ./libzstd/common/zstd_common.c:18:
./libzstd/common/zstd_internal.h:27:9: warning: ‘ZSTD_STATIC_LINKING_ONLY’ redefined
   27 | #define ZSTD_STATIC_LINKING_ONLY
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
compiling ./libzstd/compress/fse_compress.c
compiling ./libzstd/compress/hist.c
compiling ./libzstd/compress/huf_compress.c
compiling ./libzstd/compress/zstd_compress.c
In file included from ./libzstd/compress/zstd_compress.c:14:
./libzstd/compress/../common/allocations.h:18:9: warning: ‘ZSTD_STATIC_LINKING_ONLY’ redefined
   18 | #define ZSTD_STATIC_LINKING_ONLY
      |         ^~~~~~~~~~~~~~~~~~~~~~~~

...(snip)...

/usr/local/include/ruby-3.4.0/ruby/internal/intern/load.h:1:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
  +++ |+#include <stdbool.h>
    1 | #ifndef  RBIMPL_INTERN_LOAD_H                        /*-*-C++-*-vi:se ft=cpp:*/
In file included from common.h:6:
/usr/local/include/ruby-3.4.0/ruby/thread.h:217:1: error: unknown type name ‘bool’
  217 | bool rb_thread_lock_native_thread(void);
      | ^~~~
/usr/local/include/ruby-3.4.0/ruby/thread.h:1:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
  +++ |+#include <stdbool.h>
    1 | #ifndef RUBY_THREAD_H                                /*-*-C++-*-vi:se ft=cpp:*/
/usr/local/include/ruby-3.4.0/ruby/thread.h:293:1: error: unknown type name ‘bool’
  293 | bool rb_internal_thread_remove_event_hook(
      | ^~~~
/usr/local/include/ruby-3.4.0/ruby/thread.h:293:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
main.c: In function ‘Init_zstdruby’:
main.c:13:3: error: implicit declaration of function ‘rb_ext_ractor_safe’ [-Wimplicit-function-declaration]
   13 |   rb_ext_ractor_safe(true);
      |   ^~~~~~~~~~~~~~~~~~
make: *** [Makefile:251: main.o] Error 1

make failed, exit code 2
```