### PR TITLE
Fix symbol collision with other native gems using libzstd

### DIFF
--- a/ext/zstdruby/exports.txt
+++ b/ext/zstdruby/exports.txt
@@ -1,0 +1,1 @@
+_Init_zstdruby 

--- a/ext/zstdruby/extconf.rb
+++ b/ext/zstdruby/extconf.rb
@@ -2,8 +2,13 @@ require "mkmf"
 
 have_func('rb_gc_mark_movable')
 
-$CFLAGS = '-I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY -DZSTD_MULTITHREAD -pthread -DDEBUGLEVEL=0'
+$CFLAGS = '-I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY -DZSTD_MULTITHREAD -pthread -DDEBUGLEVEL=0 -fvisibility=hidden -DZSTDLIB_VISIBLE=\'__attribute__((visibility("hidden")))\' -DZSTDLIB_HIDDEN=\'__attribute__((visibility("hidden")))\''
 $CPPFLAGS += " -fdeclspec" if CONFIG['CXX'] =~ /clang/
+
+# macOS specific: Use exported_symbols_list to control symbol visibility
+if RUBY_PLATFORM =~ /darwin/
+  $LDFLAGS += " -exported_symbols_list #{File.expand_path('exports.txt', __dir__)}"
+end
 
 Dir.chdir File.expand_path('..', __FILE__) do
   $srcs = Dir['**/*.c', '**/*.S']

--- a/ext/zstdruby/main.c
+++ b/ext/zstdruby/main.c
@@ -8,7 +8,7 @@ void zstd_ruby_skippable_frame_init(void);
 void zstd_ruby_streaming_compress_init(void);
 void zstd_ruby_streaming_decompress_init(void);
 
-void
+RUBY_FUNC_EXPORTED void
 Init_zstdruby(void)
 {
 #ifdef HAVE_RB_EXT_RACTOR_SAFE


### PR DESCRIPTION
This PR fixes the symbol collision issue reported in #102 when using zstd-ruby alongside other gems that dynamically link to system libzstd (e.g., rdkafka-ruby).

## Changes Made

1. **Symbol Visibility Control**: Added  flag to hide all ZSTD symbols by default
2. **Explicit Export List**: Created  file to explicitly control which symbols are exported
3. **macOS Compatibility**: Added  flag for macOS to use the export list  
4. **Ruby Extension Initialization**: Added  macro to  function

## Root Cause

The issue was caused by zstd-ruby exporting all ZSTD symbols globally, which created conflicts when other gems expected to use system libzstd. This resulted in memory corruption and segmentation faults.

## Solution

With this fix, only the  function is exported, preventing symbol collisions while maintaining full compatibility with existing functionality.

## Testing

- All 53 existing tests pass
- Basic compression/decompression functionality verified
- Symbol visibility confirmed using  command

Fixes #102