### PR TITLE
Remove deprecated methods for v2

### DIFF
--- a/ext/zstdruby/common.h
+++ b/ext/zstdruby/common.h
@@ -18,7 +18,7 @@ static int convert_compression_level(VALUE compression_level_value)
   return NUM2INT(compression_level_value);
 }
 
-static void set_compress_params(ZSTD_CCtx* const ctx, VALUE level_from_args, VALUE kwargs)
+static void set_compress_params(ZSTD_CCtx* const ctx, VALUE kwargs)
 {
   ID kwargs_keys[2];
   kwargs_keys[0] = rb_intern("level");
@@ -29,9 +29,6 @@ static void set_compress_params(ZSTD_CCtx* const ctx, VALUE level_from_args, VAL
   int compression_level = ZSTD_CLEVEL_DEFAULT;
   if (kwargs_values[0] != Qundef && kwargs_values[0] != Qnil) {
     compression_level = convert_compression_level(kwargs_values[0]);
-  } else if (!NIL_P(level_from_args)) {
-    rb_warn("`level` in args is deprecated; use keyword args `level:` instead.");
-    compression_level = convert_compression_level(level_from_args);
   }
   ZSTD_CCtx_setParameter(ctx, ZSTD_c_compressionLevel, compression_level);
 

--- a/ext/zstdruby/streaming_compress.c
+++ b/ext/zstdruby/streaming_compress.c
@@ -71,8 +71,7 @@ static VALUE
 rb_streaming_compress_initialize(int argc, VALUE *argv, VALUE obj)
 {
   VALUE kwargs;
-  VALUE compression_level_value;
-  rb_scan_args(argc, argv, "01:", &compression_level_value, &kwargs);
+  rb_scan_args(argc, argv, "00:", &kwargs);
 
   struct streaming_compress_t* sc;
   TypedData_Get_Struct(obj, struct streaming_compress_t, &streaming_compress_type, sc);
@@ -82,7 +81,7 @@ rb_streaming_compress_initialize(int argc, VALUE *argv, VALUE obj)
   if (ctx == NULL) {
     rb_raise(rb_eRuntimeError, "%s", "ZSTD_createCCtx error");
   }
-  set_compress_params(ctx, compression_level_value, kwargs);
+  set_compress_params(ctx, kwargs);
 
   sc->ctx = ctx;
   sc->buf = rb_str_new(NULL, buffOutSize);

--- a/lib/zstd-ruby/version.rb
+++ b/lib/zstd-ruby/version.rb
@@ -1,3 +1,3 @@
 module Zstd
-  VERSION = "1.5.7.0"
+  VERSION = "2.0.0-preview1"
 end

--- a/spec/zstd-ruby-using-dict_spec.rb
+++ b/spec/zstd-ruby-using-dict_spec.rb
@@ -88,49 +88,4 @@ RSpec.describe Zstd do
     end
   end
 
-  describe 'compress_using_dict' do
-    let(:user_json) do
-      File.read("#{__dir__}/user_springmt.json")
-    end
-    let(:dictionary) do
-      File.read("#{__dir__}/dictionary")
-    end
-
-    it 'should work' do
-      compressed_using_dict = Zstd.compress_using_dict(user_json, dictionary)
-      compressed = Zstd.compress(user_json)
-      expect(compressed_using_dict.length).to be < compressed.length
-      expect(user_json).to eq(Zstd.decompress_using_dict(compressed_using_dict, dictionary))
-    end
-
-    it 'should work with simple string' do
-      compressed_using_dict = Zstd.compress_using_dict("abc", dictionary)
-      expect("abc").to eq(Zstd.decompress_using_dict(compressed_using_dict, dictionary))
-    end
-
-    it 'should work with blank input' do
-      compressed_using_dict = Zstd.compress_using_dict("", dictionary)
-      expect("").to eq(Zstd.decompress_using_dict(compressed_using_dict, dictionary))
-    end
-
-    it 'should work with blank dictionary' do
-      compressed_using_dict = Zstd.compress_using_dict(user_json, "")
-      expect(user_json).to eq(Zstd.decompress_using_dict(compressed_using_dict, ""))
-      expect(user_json).to eq(Zstd.decompress(compressed_using_dict))
-    end
-
-    it 'should support compression levels' do
-      compressed_using_dict    = Zstd.compress_using_dict(user_json, dictionary)
-      compressed_using_dict_10 = Zstd.compress_using_dict(user_json, dictionary, 10)
-      expect(compressed_using_dict_10.length).to be < compressed_using_dict.length
-      expect(user_json).to eq(Zstd.decompress_using_dict(compressed_using_dict_10, dictionary))
-    end
-
-    it 'should support compression levels with blank dictionary' do
-      compressed_using_dict_10 = Zstd.compress_using_dict(user_json, "", 10)
-      expect(user_json).to eq(Zstd.decompress_using_dict(compressed_using_dict_10, ""))
-      expect(user_json).to eq(Zstd.decompress(compressed_using_dict_10))
-    end
-  end
-
 end

--- a/spec/zstd-ruby_spec.rb
+++ b/spec/zstd-ruby_spec.rb
@@ -24,20 +24,13 @@ RSpec.describe Zstd do
       expect(compressed).to_not eq(user_json)
     end
 
-    it 'should support compression levels' do
-      compressed = Zstd.compress(user_json, 1)
-      expect(compressed).to be_a(String)
-      expect(compressed).to_not eq(user_json)
-    end
-
     it 'should support compression keyward args levels' do
       compressed = Zstd.compress(user_json, level: 1)
-      compressed_with_arg = Zstd.compress(user_json, 1)
       compressed_default = Zstd.compress(user_json)
       expect(compressed).to be_a(String)
       expect(compressed).to_not eq(user_json)
-      expect(compressed).to eq(compressed_with_arg)
-      expect(compressed_default.length).to be < compressed_with_arg.length
+      expect(compressed).to_not eq(compressed_default)
+      expect(compressed_default.length).to be < compressed.length
     end
 
     it 'should compress large bytes' do


### PR DESCRIPTION
## Summary

This PR removes deprecated functionality in preparation for the v2 release:

### Changes Made

**1. Removed deprecated positional argument for compression level:**
- Updated C extension methods (, ) to only accept keyword arguments
- Removed deprecation warnings related to positional arguments
- Updated  function signature to remove unused parameter

**2. Removed deprecated  method entirely:**
- This method was marked as deprecated and is now completely removed

**3. Updated test suite:**
- Removed tests for positional compression level arguments
- Removed all tests for the  method
- Updated remaining tests to reflect the new API

### Breaking Changes

This is a **breaking change** for v2:
- Users must now use keyword arguments for compression level:  instead of 
- The  method is no longer available
