### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,8 @@
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
 name: Ruby
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SpringMT/zstd-ruby/security/code-scanning/10](https://github.com/SpringMT/zstd-ruby/security/code-scanning/10)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the root level of the workflow file (above `jobs:`), so it applies to all jobs unless overridden. For this workflow, which only checks out code and runs tests/benchmarks, the minimal required permission is `contents: read`. This change should be made by inserting the following block after the `name:` field and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
