### PR TITLE
Prevent GC compaction and unintended sweeps for preventing checksum mismatch

### DIFF
--- a/ext/zstdruby/streaming_compress.c
+++ b/ext/zstdruby/streaming_compress.c
@@ -105,10 +105,10 @@ static VALUE
 no_compress(struct streaming_compress_t* sc, ZSTD_EndDirective endOp)
 {
   ZSTD_inBuffer input = { NULL, 0, 0 };
-  const char* output_data = RSTRING_PTR(sc->buf);
   VALUE result = rb_str_new(0, 0);
   size_t ret;
   do {
+    const char* output_data = RSTRING_PTR(sc->buf);
     ZSTD_outBuffer output = { (void*)output_data, sc->buf_size, 0 };
 
     ret = zstd_stream_compress(sc->ctx, &output, &input, endOp, false);
@@ -131,9 +131,9 @@ rb_streaming_compress_compress(VALUE obj, VALUE src)
   struct streaming_compress_t* sc;
   TypedData_Get_Struct(obj, struct streaming_compress_t, &streaming_compress_type, sc);
 
-  const char* output_data = RSTRING_PTR(sc->buf);
   VALUE result = rb_str_new(0, 0);
   while (input.pos < input.size) {
+    const char* output_data = RSTRING_PTR(sc->buf);
     ZSTD_outBuffer output = { (void*)output_data, sc->buf_size, 0 };
     size_t const ret = zstd_stream_compress(sc->ctx, &output, &input, ZSTD_e_continue, false);
     if (ZSTD_isError(ret)) {
@@ -150,7 +150,6 @@ rb_streaming_compress_write(int argc, VALUE *argv, VALUE obj)
   size_t total = 0;
   struct streaming_compress_t* sc;
   TypedData_Get_Struct(obj, struct streaming_compress_t, &streaming_compress_type, sc);
-  const char* output_data = RSTRING_PTR(sc->buf);
 
   while (argc-- > 0) {
     VALUE str = *argv++;
@@ -161,6 +160,7 @@ rb_streaming_compress_write(int argc, VALUE *argv, VALUE obj)
     VALUE result = rb_str_new(0, 0);
 
     while (input.pos < input.size) {
+      const char* output_data = RSTRING_PTR(sc->buf);
       ZSTD_outBuffer output = { (void*)output_data, sc->buf_size, 0 };
       size_t const ret = zstd_stream_compress(sc->ctx, &output, &input, ZSTD_e_continue, false);
       if (ZSTD_isError(ret)) {

--- a/ext/zstdruby/streaming_compress.c
+++ b/ext/zstdruby/streaming_compress.c
@@ -205,9 +205,9 @@ rb_streaming_compress_flush(VALUE obj)
   struct streaming_compress_t* sc;
   TypedData_Get_Struct(obj, struct streaming_compress_t, &streaming_compress_type, sc);
   VALUE drained = no_compress(sc, ZSTD_e_flush);
-  rb_str_cat(sc->pending, RSTRING_PTR(drained), RSTRING_LEN(drained));
-  VALUE out = sc->pending;
-  sc->pending = rb_str_new(0, 0);
+  VALUE out = rb_str_dup(sc->pending);
+  rb_str_cat(out, RSTRING_PTR(drained), RSTRING_LEN(drained));
+  rb_str_resize(sc->pending, 0);
   return out;
 }
 

--- a/ext/zstdruby/streaming_compress.c
+++ b/ext/zstdruby/streaming_compress.c
@@ -111,7 +111,7 @@ no_compress(struct streaming_compress_t* sc, ZSTD_EndDirective endOp)
   do {
     ZSTD_outBuffer output = { (void*)output_data, sc->buf_size, 0 };
 
-    size_t const ret = zstd_stream_compress(sc->ctx, &output, &input, endOp, false);
+    ret = zstd_stream_compress(sc->ctx, &output, &input, endOp, false);
     if (ZSTD_isError(ret)) {
       rb_raise(rb_eRuntimeError, "flush error error code: %s", ZSTD_getErrorName(ret));
     }

--- a/ext/zstdruby/streaming_compress.c
+++ b/ext/zstdruby/streaming_compress.c
@@ -157,7 +157,6 @@ rb_streaming_compress_write(int argc, VALUE *argv, VALUE obj)
     const char* input_data = RSTRING_PTR(str);
     size_t input_size = RSTRING_LEN(str);
     ZSTD_inBuffer input = { input_data, input_size, 0 };
-    VALUE result = rb_str_new(0, 0);
 
     while (input.pos < input.size) {
       const char* output_data = RSTRING_PTR(sc->buf);
@@ -166,12 +165,11 @@ rb_streaming_compress_write(int argc, VALUE *argv, VALUE obj)
       if (ZSTD_isError(ret)) {
         rb_raise(rb_eRuntimeError, "compress error error code: %s", ZSTD_getErrorName(ret));
       }
-      /* collect produced bytes */
+      /* Directly append to the pending buffer */
       if (output.pos > 0) {
-        rb_str_cat(result, output.dst, output.pos);
+        rb_str_cat(sc->pending, output.dst, output.pos);
       }
     }
-    rb_str_cat(sc->pending, RSTRING_PTR(result), RSTRING_LEN(result));
     total += RSTRING_LEN(str);
   }
 

--- a/ext/zstdruby/streaming_compress.c
+++ b/ext/zstdruby/streaming_compress.c
@@ -217,9 +217,9 @@ rb_streaming_compress_finish(VALUE obj)
   struct streaming_compress_t* sc;
   TypedData_Get_Struct(obj, struct streaming_compress_t, &streaming_compress_type, sc);
   VALUE drained = no_compress(sc, ZSTD_e_end);
-  rb_str_cat(sc->pending, RSTRING_PTR(drained), RSTRING_LEN(drained));
-  VALUE out = sc->pending;
-  sc->pending = rb_str_new(0, 0);
+  VALUE out = rb_str_dup(sc->pending);
+  rb_str_cat(out, RSTRING_PTR(drained), RSTRING_LEN(drained));
+  rb_str_resize(sc->pending, 0);
   return out;
 }
 

--- a/ext/zstdruby/streaming_compress.c
+++ b/ext/zstdruby/streaming_compress.c
@@ -158,6 +158,7 @@ rb_streaming_compress_write(int argc, VALUE *argv, VALUE obj)
     const char* input_data = RSTRING_PTR(str);
     size_t input_size = RSTRING_LEN(str);
     ZSTD_inBuffer input = { input_data, input_size, 0 };
+    VALUE result = rb_str_new(0, 0);
 
     while (input.pos < input.size) {
       ZSTD_outBuffer output = { (void*)output_data, sc->buf_size, 0 };
@@ -167,9 +168,10 @@ rb_streaming_compress_write(int argc, VALUE *argv, VALUE obj)
       }
       /* collect produced bytes */
       if (output.pos > 0) {
-        rb_str_cat(sc->pending, output.dst, output.pos);
+        rb_str_cat(result, output.dst, output.pos);
       }
     }
+    rb_str_cat(sc->pending, RSTRING_PTR(result), RSTRING_LEN(result));
     total += RSTRING_LEN(str);
   }
 

--- a/ext/zstdruby/streaming_compress.c
+++ b/ext/zstdruby/streaming_compress.c
@@ -169,9 +169,10 @@ rb_streaming_compress_write(int argc, VALUE *argv, VALUE obj)
       if (output.pos > 0) {
         rb_str_cat(sc->pending, output.dst, output.pos);
       }
-      total += RSTRING_LEN(str);
     }
+    total += RSTRING_LEN(str);
   }
+
   return SIZET2NUM(total);
 }
 

--- a/ext/zstdruby/streaming_decompress.c
+++ b/ext/zstdruby/streaming_decompress.c
@@ -101,16 +101,22 @@ rb_streaming_decompress_decompress(VALUE obj, VALUE src)
   struct streaming_decompress_t* sd;
   TypedData_Get_Struct(obj, struct streaming_decompress_t, &streaming_decompress_type, sd);
   VALUE result = rb_str_new(0, 0);
-  size_t ret;
-  do {
+
+  while (input.pos < input.size) {
     const char* output_data = RSTRING_PTR(sd->buf);
     ZSTD_outBuffer output = { (void*)output_data, sd->buf_size, 0 };
-    ret = zstd_stream_decompress(sd->dctx, &output, &input, false);
+    size_t const ret = zstd_stream_decompress(sd->dctx, &output, &input, false);
+
     if (ZSTD_isError(ret)) {
       rb_raise(rb_eRuntimeError, "decompress error error code: %s", ZSTD_getErrorName(ret));
     }
-    rb_str_cat(result, output.dst, output.pos);
-  } while (input.pos < input.size && ret > 0);
+    if (output.pos > 0) {
+        rb_str_cat(result, output.dst, output.pos);
+    }
+    if (ret == 0 && output.pos == 0) {
+        break;
+    }
+  }
   return result;
 }
 

--- a/ext/zstdruby/streaming_decompress.c
+++ b/ext/zstdruby/streaming_decompress.c
@@ -102,14 +102,15 @@ rb_streaming_decompress_decompress(VALUE obj, VALUE src)
   TypedData_Get_Struct(obj, struct streaming_decompress_t, &streaming_decompress_type, sd);
   const char* output_data = RSTRING_PTR(sd->buf);
   VALUE result = rb_str_new(0, 0);
-  while (input.pos < input.size) {
+  size_t ret;
+  do {
     ZSTD_outBuffer output = { (void*)output_data, sd->buf_size, 0 };
-    size_t const ret = zstd_stream_decompress(sd->dctx, &output, &input, false);
+    ret = zstd_stream_decompress(sd->dctx, &output, &input, false);
     if (ZSTD_isError(ret)) {
       rb_raise(rb_eRuntimeError, "decompress error error code: %s", ZSTD_getErrorName(ret));
     }
     rb_str_cat(result, output.dst, output.pos);
-  }
+  } while (input.pos < input.size && ret > 0);
   return result;
 }
 

--- a/ext/zstdruby/streaming_decompress.c
+++ b/ext/zstdruby/streaming_decompress.c
@@ -100,10 +100,10 @@ rb_streaming_decompress_decompress(VALUE obj, VALUE src)
 
   struct streaming_decompress_t* sd;
   TypedData_Get_Struct(obj, struct streaming_decompress_t, &streaming_decompress_type, sd);
-  const char* output_data = RSTRING_PTR(sd->buf);
   VALUE result = rb_str_new(0, 0);
   size_t ret;
   do {
+    const char* output_data = RSTRING_PTR(sd->buf);
     ZSTD_outBuffer output = { (void*)output_data, sd->buf_size, 0 };
     ret = zstd_stream_decompress(sd->dctx, &output, &input, false);
     if (ZSTD_isError(ret)) {


### PR DESCRIPTION
With this repro which is based on https://github.com/SpringMT/zstd-ruby/issues/112#issue-3320682543

```ruby
require "digest"
require "tempfile"

$LOAD_PATH.unshift File.expand_path('lib', __dir__)
require 'zstd-ruby'

puts "Zstd::VERSION=#{Zstd::VERSION}"

def compare_compressed(original:, compressed:)
  begin
    decompressed = Zstd.decompress(compressed)
  rescue => e
    decompress_error = e
  end

  if original != decompressed
    if decompress_error
      puts "Decompression error for #{original.bytesize} bytes input (#{decompress_error})"
    else
      puts "Content mismatch for #{original.bytesize} bytes input"
    end

    puts "  Original:        #{original.bytesize} bytes, #{Digest::SHA256.hexdigest(original)[0, 10]} checksum"

    if decompressed
      puts "  Zstd.decompress: #{decompressed.bytesize} bytes, #{Digest::SHA256.hexdigest(decompressed)[0, 10]} checksum"
    end

    begin
      cli_decompressed = Tempfile.create(binmode: true) do |temp_write|
        temp_write.write(compressed)
        temp_write.close
        Tempfile.create(binmode: true) do |temp_read|
          system "zstd", "--decompress", "--quiet", "--force", "-o", temp_read.path, temp_write.path, exception: true
          File.read(temp_read.path, binmode: true)
        end
      end

      puts "  zstd cli:        #{cli_decompressed.bytesize} bytes, #{Digest::SHA256.hexdigest(cli_decompressed)[0, 10]} checksum"
    rescue => e
      puts "  zstd cli error: #{e}"
    end
  end
end

def test_stream_write
  (1..256_000).each do |length|
    original = "a" * length

    stream = Zstd::StreamingCompress.new
    stream << original
    res = stream.finish

    compare_compressed(original: original, compressed: res)
  end
end

def test_stream_compress
  (1..256_000).each do |length|
    original = "a" * length

    stream = Zstd::StreamingCompress.new
    res = stream.compress(original)
    res << stream.finish

    compare_compressed(original: original, compressed: res)
  end
end

def test_compress
  (1..256_000).each do |length|
    original = "a" * length

    res = Zstd.compress(original)

    compare_compressed(original: original, compressed: res)
  end
end

def debug_specific_size(length)
  puts "=== Debugging size #{length} ==="
  original = "a" * length

  # 1. Generate the "good" stream using the working .compress method
  stream_good = Zstd::StreamingCompress.new
  good_compressed = stream_good.compress(original)
  good_compressed << stream_good.finish
  File.write("good.zst", good_compressed)
  puts "Saved working output to good.zst (#{good_compressed.bytesize} bytes)"

  # 2. Generate the "bad" stream using the failing << method
  stream_bad = Zstd::StreamingCompress.new
  stream_bad << original
  bad_compressed = stream_bad.finish
  File.write("bad.zst", bad_compressed)
  puts "Saved failing output to bad.zst (#{bad_compressed.bytesize} bytes)"
  puts
end

case ARGV[0]
when "stream_write"
  puts "=== Zstd::StreamingCompress.new with << ==="
  test_stream_write
when "stream_compress"
  puts "=== Zstd::StreamingCompress.new with .compress ==="
  test_stream_compress
when "compress"
  puts "=== Zstd.compress ==="
  test_compress
when "debug"
  size = ARGV[1].to_i
  if size <= 0
    abort "Please provide a specific size to debug, e.g., 'ruby zstd_repro.rb debug 20086'"
  end
  debug_specific_size(size)
else
  abort "Unknown test mode: #{ARGV[0].inspect}"
end
```

And using with rspec tests, there is no issues and checksum mismatches reported.

```
$ bundle exec rspec

<snip>
Finished in 15.39 seconds (files took 0.12929 seconds to load)
60 examples, 0 failures
```

```console
% ruby zstd_repro.rb compress
Zstd::VERSION=2.0.0
=== Zstd.compress ===
% ruby zstd_repro.rb stream_compress
Zstd::VERSION=2.0.0
=== Zstd::StreamingCompress.new with .compress ===
% ruby zstd_repro.rb stream_write
Zstd::VERSION=2.0.0
=== Zstd::StreamingCompress.new with << ===
```