### PR TITLE
CI: Support Ruby 3.5

### DIFF
--- a/spec/zstd-ruby-streaming-compress_spec.rb
+++ b/spec/zstd-ruby-streaming-compress_spec.rb
@@ -115,7 +115,11 @@ RSpec.describe Zstd::StreamingCompress do
           stream << "abc" << "def"
           res = stream.finish
         }
-        expect(Zstd.decompress(r.take)).to eq('abcdef')
+        # Ractor#take was replaced at Ruby 3.5.
+        # https://bugs.ruby-lang.org/issues/21262
+        result = r.respond_to?(:take) ? r.take : r.value
+
+        expect(Zstd.decompress(result)).to eq('abcdef')
       end
     end
   end

--- a/spec/zstd-ruby-streaming-decompress_spec.rb
+++ b/spec/zstd-ruby-streaming-decompress_spec.rb
@@ -169,7 +169,11 @@ RSpec.describe Zstd::StreamingDecompress do
           result << stream.decompress(cstr[10..-1])
           result
         }
-        expect(r.take).to eq('foo bar buzz')
+        # Ractor#take was replaced at Ruby 3.5.
+        # https://bugs.ruby-lang.org/issues/21262
+        result = r.respond_to?(:take) ? r.take : r.value
+
+        expect(result).to eq('foo bar buzz')
       end
     end
   end

--- a/spec/zstd-ruby_spec.rb
+++ b/spec/zstd-ruby_spec.rb
@@ -118,7 +118,11 @@ RSpec.describe Zstd do
     describe 'Ractor' do
       it 'should be supported' do
         r = Ractor.new { Zstd.compress('abc') }
-        expect(Zstd.decompress(r.take)).to eq('abc')
+        # Ractor#take was replaced at Ruby 3.5.
+        # https://bugs.ruby-lang.org/issues/21262
+        result = r.respond_to?(:take) ? r.take : r.value
+
+        expect(Zstd.decompress(result)).to eq('abc')
       end
     end
   end


### PR DESCRIPTION
Ractor#take was replaced at Ruby 3.5.
https://bugs.ruby-lang.org/issues/21262

This patch will fix following error with Ruby 3.5 dev:

```
Failures:

  1) Zstd::StreamingCompress Ractor should be supported
     Failure/Error: expect(Zstd.decompress(r.take)).to eq('abcdef')
     
     NoMethodError:
       undefined method 'take' for an instance of Ractor
     # ./spec/zstd-ruby-streaming-compress_spec.rb:118:in 'block (3 levels) in <top (required)>'

  2) Zstd::StreamingDecompress Ractor should be supported
     Failure/Error: expect(r.take).to eq('foo bar buzz')
     
     NoMethodError:
       undefined method 'take' for an instance of Ractor
     # ./spec/zstd-ruby-streaming-decompress_spec.rb:172:in 'block (3 levels) in <top (required)>'

  3) Zstd Ractor should be supported
     Failure/Error: expect(Zstd.decompress(r.take)).to eq('abc')
     
     NoMethodError:
       undefined method 'take' for an instance of Ractor
     # ./spec/zstd-ruby_spec.rb:121:in 'block (3 levels) in <top (required)>'
```
