### PR TITLE
Allow build time --with-cflags option to work

### DIFF
--- a/ext/zstdruby/extconf.rb
+++ b/ext/zstdruby/extconf.rb
@@ -26,7 +26,7 @@ def ext_export_filename
   name
 end
 
-$CFLAGS += '-I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY -DZSTD_MULTITHREAD -pthread -DDEBUGLEVEL=0 -fvisibility=hidden -DZSTDLIB_VISIBLE=\'__attribute__((visibility("hidden")))\' -DZSTDLIB_HIDDEN=\'__attribute__((visibility("hidden")))\''
+$CFLAGS += ' -I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY -DZSTD_MULTITHREAD -pthread -DDEBUGLEVEL=0 -fvisibility=hidden -DZSTDLIB_VISIBLE=\'__attribute__((visibility("hidden")))\' -DZSTDLIB_HIDDEN=\'__attribute__((visibility("hidden")))\''
 $CPPFLAGS += " -fdeclspec" if CONFIG['CXX'] =~ /clang/
 
 # macOS specific: Use exported_symbols_list to control symbol visibility

--- a/ext/zstdruby/extconf.rb
+++ b/ext/zstdruby/extconf.rb
@@ -26,7 +26,7 @@ def ext_export_filename
   name
 end
 
-$CFLAGS = '-I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY -DZSTD_MULTITHREAD -pthread -DDEBUGLEVEL=0 -fvisibility=hidden -DZSTDLIB_VISIBLE=\'__attribute__((visibility("hidden")))\' -DZSTDLIB_HIDDEN=\'__attribute__((visibility("hidden")))\''
+$CFLAGS += '-I. -O3 -std=c99 -DZSTD_STATIC_LINKING_ONLY -DZSTD_MULTITHREAD -pthread -DDEBUGLEVEL=0 -fvisibility=hidden -DZSTDLIB_VISIBLE=\'__attribute__((visibility("hidden")))\' -DZSTDLIB_HIDDEN=\'__attribute__((visibility("hidden")))\''
 $CPPFLAGS += " -fdeclspec" if CONFIG['CXX'] =~ /clang/
 
 # macOS specific: Use exported_symbols_list to control symbol visibility


### PR DESCRIPTION
The current extconfg.rb overwrites `$CFLAGS` variable breaking usual `gem install zstd-ruby -- --with-cflags="..."` way of setting it

I ran into this when trying to compile the gem with musl on arm64 where a `PATH_MAX` constant is not set, and couldn't get `gem` command to add it to the generated makefile with `--with-cflags`

As a workaround `--with-cppflags="..."` works because that is already with `+=` in extconf, but i see no reason why break normal cflags