### PR TITLE
Fix out-of-bounds read in Zstd.write_skippable_frame

### DIFF
--- a/ext/zstdruby/skippable_frame.c
+++ b/ext/zstdruby/skippable_frame.c
@@ -17,13 +17,12 @@ static VALUE rb_write_skippable_frame(int argc, VALUE *argv, VALUE self)
 
   StringValue(input_value);
   StringValue(skip_value);
-  char* input_data = RSTRING_PTR(input_value);
   size_t input_size = RSTRING_LEN(input_value);
   char* skip_data = RSTRING_PTR(skip_value);
   size_t skip_size = RSTRING_LEN(skip_value);
 
   size_t dst_size = input_size + ZSTD_SKIPPABLEHEADERSIZE + skip_size;
-  VALUE output = rb_str_new(input_data, dst_size);
+  VALUE output = rb_str_new(NULL, dst_size);
   char* output_data = RSTRING_PTR(output);
   size_t output_size = ZSTD_writeSkippableFrame((void*)output_data, dst_size, (const void*)skip_data, skip_size, magic_variant);
   if (ZSTD_isError(output_size)) {

--- a/spec/zstd-skippable_frame_spec.rb
+++ b/spec/zstd-skippable_frame_spec.rb
@@ -30,5 +30,13 @@ RSpec.describe Zstd do
       end
     end
 
+    context 'large input (heap-allocated) + skippable frame' do
+      it 'round-trips without breaking' do
+        payload = 'A' * 1024
+        skippable = 'sample data'
+        frame = Zstd.write_skippable_frame(payload, skippable)
+        expect(Zstd.read_skippable_frame(frame)).to eq skippable
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix #136