### PR TITLE
Fix Zstd.decompress dropping all but the first of concatenated frames

### DIFF
--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -40,7 +40,7 @@ static VALUE rb_compress(int argc, VALUE *argv, VALUE self)
   return output;
 }
 
-static VALUE decode_one_frame(ZSTD_DCtx* dctx, const unsigned char* src, size_t size, VALUE kwargs) {
+static VALUE decode_one_frame(ZSTD_DCtx* dctx, const unsigned char* src, size_t size, VALUE kwargs, size_t* consumed) {
   VALUE out = rb_str_buf_new(0);
   size_t cap = ZSTD_DStreamOutSize();
   char *buf = ALLOC_N(char, cap);
@@ -64,11 +64,14 @@ static VALUE decode_one_frame(ZSTD_DCtx* dctx, const unsigned char* src, size_t 
     }
   }
   xfree(buf);
+  if (consumed) {
+    *consumed = in.pos;
+  }
   return out;
 }
 
 static VALUE decompress_buffered(ZSTD_DCtx* dctx, const char* data, size_t len) {
-  return decode_one_frame(dctx, (const unsigned char*)data, len, Qnil);
+  return decode_one_frame(dctx, (const unsigned char*)data, len, Qnil, NULL);
 }
 
 static VALUE rb_decompress(int argc, VALUE *argv, VALUE self)
@@ -83,6 +86,9 @@ static VALUE rb_decompress(int argc, VALUE *argv, VALUE self)
   size_t off = 0;
   const uint32_t ZSTD_MAGIC = 0xFD2FB528U;
   const uint32_t SKIP_LO    = 0x184D2A50U; /* ...5F */
+
+  VALUE result = Qnil;
+  ZSTD_DCtx *dctx = NULL;
 
   while (off + 4 <= in_size) {
     uint32_t magic = (uint32_t)in[off]
@@ -103,23 +109,43 @@ static VALUE rb_decompress(int argc, VALUE *argv, VALUE self)
     }
 
     if (magic == ZSTD_MAGIC) {
-      ZSTD_DCtx *dctx = ZSTD_createDCtx();
-      if (!dctx) {
-        rb_raise(rb_eRuntimeError, "ZSTD_createDCtx failed");
+      if (dctx == NULL) {
+        dctx = ZSTD_createDCtx();
+        if (!dctx) {
+          rb_raise(rb_eRuntimeError, "ZSTD_createDCtx failed");
+        }
       }
 
-      VALUE out = decode_one_frame(dctx, in + off, in_size - off, kwargs);
+      size_t consumed = 0;
+      VALUE out = decode_one_frame(dctx, in + off, in_size - off, kwargs, &consumed);
+      if (result == Qnil) {
+        /* First frame becomes the accumulator, avoiding a copy of its
+           (potentially large) output in the common single-frame case. */
+        result = out;
+      } else {
+        rb_str_cat(result, RSTRING_PTR(out), RSTRING_LEN(out));
+      }
 
-      ZSTD_freeDCtx(dctx);
-      RB_GC_GUARD(input_value);
-      return out;
+      if (consumed == 0) {
+        /* Guard against a non-advancing frame to avoid an infinite loop. */
+        break;
+      }
+      off += consumed;
+      continue;
     }
 
     off += 1;
   }
 
+  if (dctx != NULL) {
+    ZSTD_freeDCtx(dctx);
+  }
+
   RB_GC_GUARD(input_value);
-  rb_raise(rb_eRuntimeError, "not a zstd frame (magic not found)");
+  if (result == Qnil) {
+    rb_raise(rb_eRuntimeError, "not a zstd frame (magic not found)");
+  }
+  return result;
 }
 
 static void free_cdict(void *dict)

--- a/spec/zstd-ruby_spec.rb
+++ b/spec/zstd-ruby_spec.rb
@@ -99,6 +99,19 @@ RSpec.describe Zstd do
       expect(Zstd.decompress(res)).to eq(large_strings * 3)
     end
 
+    it 'should decompress concatenated frames' do
+      a = Zstd.compress("Hello, ")
+      b = Zstd.compress("World!")
+      expect(Zstd.decompress(a + b)).to eq("Hello, World!")
+    end
+
+    it 'should decompress three or more concatenated frames' do
+      a = Zstd.compress("Hello, ")
+      b = Zstd.compress("World!")
+      c = Zstd.compress("!!!")
+      expect(Zstd.decompress(a + b + c)).to eq("Hello, World!!!!")
+    end
+
     it 'should raise exception with unsupported object' do
       expect { Zstd.decompress(Object.new) }.to raise_error(TypeError)
     end


### PR DESCRIPTION
Fixes #138

## Problem

`Zstd.decompress` only decoded the **first** frame of concatenated zstd frames and silently dropped the rest. The zstd format explicitly supports frame concatenation (e.g. `cat a.zst b.zst | zstd -d` yields the concatenation of both), and `ZSTD_decompress` / `ZSTD_decompressStream` decode all frames, so the previous behavior diverged from the format.

```ruby
a = Zstd.compress("Hello, ")
b = Zstd.compress("World!")
Zstd.decompress(a + b)
# => "Hello, "          (before)
# => "Hello, World!"    (after)
```

## Cause

`rb_decompress` returned immediately after decoding the first data frame instead of looping back to process the remaining input. (The skippable-frame branch already advanced `off` and continued the loop; the data-frame branch did not.)

## Fix

- `decode_one_frame` now reports how many input bytes it consumed (the final `ZSTD_inBuffer.pos`) via a new `size_t* consumed` out-parameter, so the caller can advance past the frame. The existing `decompress_buffered` caller is updated to pass `NULL`.
- `rb_decompress` scans the whole input, accumulating every frame's output:
  * A single `DCtx` is created once and reused across frames (`decode_one_frame` already resets the session via `ZSTD_reset_session_only`), and freed after the loop.
  * The first frame's output becomes the accumulator and subsequent frames are appended with `rb_str_cat`, so the common single-frame case stays zero-copy.
  * `off` is advanced by the consumed byte count and the loop continues; a `consumed == 0` guard prevents an infinite loop.
  * Existing skippable-frame handling, magic scanning, the "not a zstd frame" `rb_raise`, and `RB_GC_GUARD(input_value)` are preserved.

Out of scope: `dict:`/kwargs handling, streaming, and skippable-frame behavior are unchanged. The public API signature and return type of `Zstd.decompress` are unchanged.

## Verification

`bundle exec rake spec` passes (17 examples, 0 failures), with no new compiler warnings. New regression specs cover concatenated frames:

- `a + b` decompresses to `"Hello, World!"`
- a three-frame input (`a + b + c`) is fully concatenated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
