### PR TITLE
Fix incorrect sample code in README (DDict usage and CDict example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ res << stream.finish
 
 #### Streaming Compression with CDict of level 5
 ```ruby
-cdict = Zstd::CDict.new(File.read('dictionary_file', 5)
+cdict = Zstd::CDict.new(File.read('dictionary_file'), 5)
 stream = Zstd::StreamingCompress.new(dict: cdict)
 stream << "abc" << "def"
 res = stream.flush
@@ -143,8 +143,8 @@ Zstd.decompress(compressed_using_dict, dict: File.read('dictionary_file'))
 If you use the same dictionary repeatedly, you can speed up the setup by creating DDict in advance:
 
 ```ruby
-ddict = Zstd::Ddict.new(File.read('dictionary_file'))
-data = Zstd.compress(compressed_using_dict, ddict)
+ddict = Zstd::DDict.new(File.read('dictionary_file'))
+data = Zstd.decompress(compressed_using_dict, dict: ddict)
 ```
 
 #### Streaming Decompression


### PR DESCRIPTION
Fixes incorrect sample code in README.md.

- **Decompression with DDict example**: Fixed the class name `Ddict` → `DDict`; since this is a decompression example, changed `compress` → `decompress`; and pass the dictionary via the `dict:` keyword argument to be consistent with the other `decompress` examples.
- **Streaming Compression with CDict of level 5 example**: Fixed the parenthesis placement so the compression level `5` is passed as the second argument of `CDict.new` instead of being passed to `File.read`.

This only changes README.md; no code, tests, or gemspec are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)