### PR TITLE
Validate String argument in Zstd.read_skippable_frame

### DIFF
--- a/ext/zstdruby/skippable_frame.c
+++ b/ext/zstdruby/skippable_frame.c
@@ -36,6 +36,7 @@ static VALUE rb_write_skippable_frame(int argc, VALUE *argv, VALUE self)
 
 static VALUE rb_read_skippable_frame(VALUE self, VALUE input_value)
 {
+  StringValue(input_value);
   char* input_data = RSTRING_PTR(input_value);
   size_t input_size = RSTRING_LEN(input_value);
 

--- a/spec/zstd-skippable_frame_spec.rb
+++ b/spec/zstd-skippable_frame_spec.rb
@@ -30,5 +30,22 @@ RSpec.describe Zstd do
       end
     end
 
+    context 'non-String argument' do
+      [nil, 123456789, :symbol, [1, 2, 3], Object.new].each do |arg|
+        it "raises TypeError for #{arg.class}" do
+          expect { Zstd.read_skippable_frame(arg) }.to raise_error(TypeError)
+        end
+      end
+    end
+
+    context 'String-convertible argument' do
+      it 'accepts objects responding to #to_str' do
+        compressed_data = Zstd.compress(SecureRandom.hex(150))
+        frame = Zstd.write_skippable_frame(compressed_data, "sample data")
+        convertible = Object.new
+        convertible.define_singleton_method(:to_str) { frame }
+        expect(Zstd.read_skippable_frame(convertible)).to eq "sample data"
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

`Zstd.read_skippable_frame` called `RSTRING_PTR` / `RSTRING_LEN` on its
argument **without** going through `StringValue()`, unlike every other
public API in this gem (`compress`, `decompress`, `write_skippable_frame`,
streaming compress/decompress all do).

Passing a non-String therefore reinterpreted the object as an `RString`
and dereferenced its `ptr`/`len` fields, leading to a crash. For example a
`Fixnum` argument crashed at an address derived from its immediate value:

```ruby
Zstd.read_skippable_frame(nil)        # SEGV
Zstd.read_skippable_frame(123456789)  # SEGV (address derived from the argument)
```

## Fix

Add `StringValue(input_value);` at the top of `rb_read_skippable_frame`,
matching the other entry points. Non-String arguments now raise
`TypeError`, while `String`-convertible objects (`#to_str`) keep working.

```c
 static VALUE rb_read_skippable_frame(VALUE self, VALUE input_value)
 {
+  StringValue(input_value);
   char* input_data = RSTRING_PTR(input_value);
   size_t input_size = RSTRING_LEN(input_value);
```

## Tests

Added specs to `spec/zstd-skippable_frame_spec.rb`:
- non-String arguments (`nil`, `Integer`, `Symbol`, `Array`, `Object`) raise `TypeError`
- objects responding to `#to_str` are still accepted

Full suite passes (`66 examples, 0 failures`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)