### PR TITLE
Add Valgrind memcheck (ruby_memcheck) for the C extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in zstd_ruby.gemspec
 gemspec
+
+gem 'ruby_memcheck', '~> 3.0' if RUBY_PLATFORM.include?('linux')

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,34 @@ end
 
 task :default => [:clobber, :compile, :spec]
 
+if RUBY_PLATFORM.include?('linux')
+  begin
+    require 'ruby_memcheck'
+    require 'ruby_memcheck/rspec/rake_task'
+
+    RubyMemcheck.config(
+      binary_name: 'zstdruby',
+      # Valgrind and YJIT interfere with each other, adding noise and slowdown,
+      # so keep YJIT disabled while running under Valgrind.
+      ruby: "#{FileUtils::RUBY} --disable-yjit"
+    )
+
+    namespace :spec do
+      task :check_valgrind do
+        unless system('command -v valgrind > /dev/null 2>&1')
+          abort("\nValgrind is required for `rake spec:valgrind` but was not found.\n" \
+                "Install it first (Linux only), e.g. `sudo apt-get install valgrind`.\n")
+        end
+      end
+
+      RubyMemcheck::RSpec::RakeTask.new(valgrind: [:check_valgrind, :compile])
+    end
+  rescue LoadError
+    # ruby_memcheck is an optional, Linux-only development dependency. If it is
+    # not installed just skip defining the task instead of breaking the Rakefile.
+  end
+end
+
 desc 'Sync zstd libs dirs to ext/zstdruby/libzstd'
 task :zstd_update do
   FileUtils.rm_r("ext/zstdruby/libzstd")


### PR DESCRIPTION
## Summary

This adds [Shopify's `ruby_memcheck`](https://github.com/Shopify/ruby_memcheck) so the spec suite can be run under Valgrind's memcheck:

```
rake spec:valgrind
```

Running Valgrind against a Ruby C extension is normally impractical, because the interpreter itself produces a large volume of reports that have nothing to do with the extension. `ruby_memcheck` wraps Valgrind and applies a heuristic that only surfaces errors whose stack trace passes through the extension's `.so`, which makes the output usable. It is the same tool Shopify runs on nokogiri and liquid-c.

The task layout follows [rmagick/rmagick#1716](https://github.com/rmagick/rmagick/pull/1716) — Linux-only guard, `valgrind: :compile` prerequisite, dependency added with a platform guard.

## What is in this PR

- `ruby_memcheck` as a **Linux-only** development dependency in the `Gemfile`. Valgrind is not usable in practice on macOS or Windows, and the `RUBY_PLATFORM.include?('linux')` guard keeps `bundle install` working there. It goes in the `Gemfile` rather than the gemspec so the packaged gem stays platform-agnostic.
- A `rake spec:valgrind` task in the `Rakefile`. It disables YJIT under Valgrind (they interfere, adding noise and slowdown) and fails early with a clear message when Valgrind is not installed. If `ruby_memcheck` itself is missing, the task is simply not defined rather than breaking the `Rakefile`.

No suppression file is included: on the current tree the suite reports nothing that needs silencing.

## Current result

Clean. `rake spec:valgrind` exits 0 with zero reports attributed to the extension — no invalid accesses, no leaks — in about 75 seconds for the 67 examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
