### PR TITLE
Remove dead decompress helpers and fix two copy-paste slips

### DIFF
--- a/ext/zstdruby/common.h
+++ b/ext/zstdruby/common.h
@@ -152,7 +152,7 @@ static VALUE set_decompress_params(ZSTD_DCtx* const dctx, VALUE kwargs)
       size_t load_dict_ret = ZSTD_DCtx_loadDictionary(dctx, dict_buffer, dict_size);
       if (ZSTD_isError(load_dict_ret)) {
         ZSTD_freeDCtx(dctx);
-        rb_raise(rb_eRuntimeError, "%s", "ZSTD_CCtx_loadDictionary failed");
+        rb_raise(rb_eRuntimeError, "%s", "ZSTD_DCtx_loadDictionary failed");
       }
     } else {
       ZSTD_freeDCtx(dctx);
@@ -188,37 +188,6 @@ static size_t zstd_stream_decompress(ZSTD_DCtx* const dctx, ZSTD_outBuffer* outp
     }
 #else
     return ZSTD_decompressStream(dctx, output, input);
-#endif
-}
-
-struct decompress_params {
-  ZSTD_DCtx* dctx;
-  char* output_data;
-  size_t output_size;
-  char* input_data;
-  size_t input_size;
-  size_t ret;
-};
-
-static void* decompress_wrapper(void* args)
-{
-    struct decompress_params* params = args;
-    params->ret = ZSTD_decompressDCtx(params->dctx, params->output_data, params->output_size, params->input_data, params->input_size);
-    return NULL;
-}
-
-static size_t zstd_decompress(ZSTD_DCtx* const dctx, char* output_data, size_t output_size, char* input_data, size_t input_size, bool gvl)
-{
-#ifdef HAVE_RUBY_THREAD_H
-    if (gvl) {
-      return ZSTD_decompressDCtx(dctx, output_data, output_size, input_data, input_size);
-    } else {
-      struct decompress_params params = { dctx, output_data, output_size, input_data, input_size };
-      rb_thread_call_without_gvl(decompress_wrapper, &params, NULL, NULL);
-      return params.ret;
-    }
-#else
-    return ZSTD_decompressDCtx(dctx, output_data, output_size, input_data, input_size);
 #endif
 }
 

--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -78,10 +78,6 @@ static VALUE decode_one_frame(ZSTD_DCtx* dctx, const unsigned char* src, size_t 
   return out;
 }
 
-static VALUE decompress_buffered(ZSTD_DCtx* dctx, const char* data, size_t len) {
-  return decode_one_frame(dctx, (const unsigned char*)data, len, Qnil, NULL);
-}
-
 static VALUE rb_decompress(int argc, VALUE *argv, VALUE self)
 {
   VALUE input_value, kwargs;
@@ -216,7 +212,7 @@ static VALUE rb_cdict_initialize(int argc, VALUE *argv, VALUE self)
 
 static VALUE rb_ddict_alloc(VALUE self)
 {
-  ZSTD_CDict* ddict = NULL;
+  ZSTD_DDict* ddict = NULL;
   return TypedData_Wrap_Struct(self, &ddict_type, ddict);
 }
 


### PR DESCRIPTION
## Summary

This is pure cleanup with no behaviour change. It's deliberately kept as a separate PR from the GVL fix so each can be reviewed independently on its own merits.

## Changes

- **Remove dead code that nothing calls any more:** the one-shot decompress path `zstd_decompress`, its `decompress_wrapper` function, and the `decompress_params` struct — all in `common.h` — plus `decompress_buffered` in `zstdruby.c`. These are leftovers from when `Zstd.decompress` was rewritten to use `decode_one_frame` / `ZSTD_decompressStream`. The streaming wrapper `stream_decompress_wrapper` is a different function that is still in use and is left untouched.

- **Fix a wrong pointer type in `rb_ddict_alloc`:** a local was declared `ZSTD_CDict*` (the compress-dictionary type) while it actually holds a decompress dictionary. Corrected to `ZSTD_DDict*`. The variable is `NULL` at that point, so this was a cosmetic type-naming issue with no functional effect.

- **Fix a wrong error message in `set_decompress_params`:** the error raised on a DDict-load failure read `"ZSTD_CCtx_loadDictionary failed"` (the compress-context function) when it should reference the decompress-context function. Corrected to `"ZSTD_DCtx_loadDictionary failed"`.

## Verification

The full test suite passes: 72 examples, 0 failures.
