### PR TITLE
Release the GVL while decompressing in Zstd.decompress

### DIFF
--- a/ext/zstdruby/zstdruby.c
+++ b/ext/zstdruby/zstdruby.c
@@ -52,7 +52,7 @@ static VALUE decode_one_frame(ZSTD_DCtx* dctx, const unsigned char* src, size_t 
   for (;;) {
     ZSTD_outBuffer o = (ZSTD_outBuffer){ buf, cap, 0 };
     size_t const in_pos_before = in.pos;
-    size_t ret = ZSTD_decompressStream(dctx, &o, &in);
+    size_t ret = zstd_stream_decompress(dctx, &o, &in, false);
     if (ZSTD_isError(ret)) {
       xfree(buf);
       rb_raise(rb_eRuntimeError, "ZSTD_decompressStream failed: %s", ZSTD_getErrorName(ret));


### PR DESCRIPTION
## Summary

Fixes #155.

The one-shot `Zstd.decompress` path holds Ruby's GVL throughout the libzstd call, blocking every other thread in the process. This routes it through the existing `zstd_stream_decompress` wrapper (already used by the streaming classes), which releases the GVL once per output chunk.

## Change

In `ext/zstdruby/zstdruby.c`, function `decode_one_frame`:

```c
-    size_t ret = ZSTD_decompressStream(dctx, &o, &in);
+    size_t ret = zstd_stream_decompress(dctx, &o, &in, false);
```

The `false` argument selects the GVL-releasing branch of the wrapper. The GVL is released and reacquired once per output chunk (`ZSTD_DStreamOutSize`, 128 KB) — the same granularity the streaming decompress path already uses, so other threads get a turn between chunks.

## Why it's safe to release the GVL here

- The scratch output buffer in `decode_one_frame` is `malloc`'d (`ALLOC_N`), not a Ruby String, so GC compaction cannot move it during the released window.
- The input pointer comes from a stack-local `VALUE`, which is conservatively pinned by the GC.

So nothing the libzstd call touches can be relocated while the GVL is released. On very old Rubies without `ruby/thread.h`, the wrapper falls back to a direct call, so behaviour there is unchanged.

## Verification

- Full suite passes: 72 examples, 0 failures.
- The reproduction from #155 flips from 0 heartbeat samples (before) to ~700 (after), with no change in decompress time — so no measurable throughput cost from the per-chunk GVL round-trip.
